### PR TITLE
Added select method to tabbar elements so it can be manually selected.

### DIFF
--- a/src/tabbar.js
+++ b/src/tabbar.js
@@ -50,6 +50,15 @@
         return (rect.left <= x && x <= rect.right &&
                 rect.top <= y && y <= rect.bottom);
     }
+    function _selectTab(tabEl) {
+      var activeTab = xtag.query(tabEl.parentNode, "x-tabbar-tab[selected]");
+        if (activeTab.length) {
+          activeTab.forEach(function(t) {
+            t.removeAttribute('selected');
+          });
+        }
+      tabEl.setAttribute('selected', true);
+    }
 
     xtag.register("x-tabbar", {
         lifecycle: {
@@ -59,13 +68,7 @@
         },
         events: {
             "tap:delegate(x-tabbar-tab)": function(e) {
-                var activeTab = xtag.query(this.parentNode, "x-tabbar-tab[selected]");
-                if (activeTab.length) {
-                    activeTab.forEach(function(t) {
-                        t.removeAttribute('selected');
-                    });
-                }
-                this.setAttribute('selected', true);
+                _selectTab(this);
             }
         },
         accessors: {
@@ -186,6 +189,11 @@
                 }
             }
         },
-        methods: {}
+        methods: { 
+          select: function() {
+              _selectTab(this);
+              _onTabbarTabTap(this);
+          }
+        }
     });
 })();


### PR DESCRIPTION
I've added a method to tabbar elements so it can be manually selected.

Eg:

``` javascript
document.getElementsByTagName('x-tabbar-tab')[0].select()
```

This method marks the specified tab as 'selected' and displays the target-element for the tabbar (using the method _onTabbarTabTap).

The method _selectTab() was extracted from the tap event from x-tabbar so I replace it current implementation to this method.
