### PR TITLE
Added select method and select event to tabbar elements

### DIFF
--- a/src/tabbar.js
+++ b/src/tabbar.js
@@ -55,9 +55,9 @@
         var activeTab = xtag.query(tabEl.parentNode, "x-tabbar-tab[selected]");
         if (activeTab.length) {
             activeTab.forEach(function(t) {
-            t.removeAttribute('selected');
-        });
-    }
+              t.removeAttribute('selected');
+            });
+        }
         tabEl.setAttribute('selected', true);
     }
 
@@ -69,10 +69,10 @@
         },
         events: {
             "select:delegate(x-tabbar-tab)": function() {
-              _selectTab(this);
+                _selectTab(this);
             },
             "tap:delegate(x-tabbar-tab)": function () {
-              _selectTab(this);
+                _selectTab(this);
             }
         },
         accessors: {


### PR DESCRIPTION
I've made the changes suggested by Potch in order to have a 'select' method on each tab.

Now It will simply fire a 'select' event which the tabbar is going to handle in order to change it.

The actual selection is made by the existing _onTabbarTabTap function (should I change its name?)
